### PR TITLE
Behapass 105 - Dokončenie migrácie na GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Aplikácia na zbieranie údajov z VR ovládačov a ich odosielanie na server. S�
 Podporovaná verzia Python 3.5+.  
 Pre správne fungovanie treba mať nainštalované [SteamVR](https://store.steampowered.com/app/250820/SteamVR/). Bez toho aplikácia len pošle ukážkové dáta na server (test API).  
 
-1. Naklonovať tento repozitár (`git clone https://bitbucket.org/behaworks/logger-client.git`).  
+1. Naklonovať tento repozitár (`git clone https://github.com/BehaWorks/logger-client.git`).  
 2. V priečinku repozitára nainštalovať závislosti: `pip install -r requirements.txt`.  
 3. Do priečinka repozitára manuálne stiahnuť knižnicu [Triad OpenVR](https://github.com/TriadSemi/triad_openvr). Stačí stiahnuť súbor `triad_openvr.py`.  
 4. Pri prvej inštalácii treba vytvoriť súbor `config/config.json`, forma podľa `config/example_config.json` (stačí skopírovať a premenovať).

--- a/logger.py
+++ b/logger.py
@@ -1,12 +1,12 @@
 import json
 import uuid
+from datetime import datetime
 from pprint import pprint
 
+import behapass_client
 import openvr
-import swagger_client
 import time
-from datetime import datetime
-from swagger_client.rest import ApiException
+from behapass_client.rest import ApiException
 
 import triad_openvr as vr
 
@@ -106,7 +106,7 @@ def post_record(api_client, controller_movements, hmd_movements, buttons):
         print("Exception when calling LoggerApi->post_logger_record: %s\n" % e)
 
 
-api_client = swagger_client.LoggerApi()
+api_client = behapass_client.LoggerApi()
 api_client.api_client.configuration.host = api_host
 
 try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git+https://bitbucket.org/behaworks/logger-python-client.git
+git+https://github.com/BehaWorks/logger-python-client.git
 openvr==1.7.1501


### PR DESCRIPTION
V `requirements.txt` a `README.md` boli ešte staré odkazy na BitBucketové repozitáre.

Zmena `swagger_client` na `behapass_client`, lebo v najnovšej verzii generovaného API klienta na GitHube sa už ten modul volá rozumne, viď [repozitár](https://github.com/BehaWorks/logger-python-client).